### PR TITLE
Fix mismatched div in rota preview

### DIFF
--- a/app.py
+++ b/app.py
@@ -136,8 +136,6 @@ def display_latest_rota(rotas):
             file_name=f"rota_{latest_week}.png",
             mime="image/png"
         )
-        
-        st.markdown("</div>", unsafe_allow_html=True)
     else:
         st.info("📭 No rota available for this week or upcoming weeks.")
 


### PR DESCRIPTION
## Summary
- remove stray closing `div` tag from `display_latest_rota`

## Testing
- `python -m py_compile app.py weekly_rota_generation.py admin_panel.py core/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684caa3ae6d083258d22b1b97f2b5d12