### PR TITLE
Fix newline replacement in admin panel

### DIFF
--- a/admin_panel.py
+++ b/admin_panel.py
@@ -20,7 +20,7 @@ SCOPE = ["https://spreadsheets.google.com/feeds", "https://www.googleapis.com/au
 # ─── Google Sheets Authorization ───
 try:
     creds_dict = dict(st.secrets["gcp_service_account"])
-    creds_dict["private_key"] = creds_dict["private_key"].replace("\n", "\n")
+    creds_dict["private_key"] = creds_dict["private_key"].replace("\\n", "\n")
     creds = Credentials.from_service_account_info(creds_dict, scopes=SCOPE)
     gspread_client = gspread.authorize(creds)
 except Exception as e:


### PR DESCRIPTION
## Summary
- ensure Google Sheets private_key replaces escaped newlines with real ones

## Testing
- `python -m py_compile admin_panel.py`


------
https://chatgpt.com/codex/tasks/task_e_684cad9739388325a8b65150520faab8