### PR TITLE
Remove redundant imports from utils

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -3,8 +3,6 @@ from io import BytesIO
 import matplotlib.pyplot as plt
 
 def generate_table_image(df, title=None):
-    from io import BytesIO
-    import matplotlib.pyplot as plt
 
     fig_height = len(df) * 0.43 + 0.6
     fig, ax = plt.subplots(figsize=(12, fig_height))


### PR DESCRIPTION
## Summary
- clean up `generate_table_image` by dropping inner import statements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb1485bb083259cca0636f7dc77d2