### PR TITLE
Implement selective login gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A smart, fair, and fully automated rota management system designed for ABP Yetmi
 - 📈 **Monthly FCI/OFFLINE Overview**
 - 🗂️ **Editable & Collapsible Saved Weekly Rotas**
 - 🎨 **Modern UI with Auto Validation & Warnings**
+- 🔑 **Password-protected management features**
 
 ## 🚀 Version 1.3.5 (Stable)
 
@@ -43,6 +44,10 @@ cd 8216-rota-planner
 pip install -r requirements.txt
 streamlit run app.py
 ```
+
+The default management password is `8216`. Set the `APP_PASSWORD` environment
+variable to use a custom password. Viewing saved rotas does not require a
+password.
 
 ## 🧪 Running Tests
 

--- a/app.py
+++ b/app.py
@@ -28,6 +28,24 @@ from weekly_rota_generation import (
 # ─────────────────────────────────────────────
 st.set_page_config(page_title="8216 ABP Yetminster Weekly Rota Planner", layout="wide")
 
+APP_PASSWORD = os.getenv("APP_PASSWORD", "8216")
+
+
+def require_app_password():
+    if "authenticated" not in st.session_state:
+        st.session_state["authenticated"] = False
+
+    if not st.session_state["authenticated"]:
+        st.markdown("### 🔑 Enter password to manage rotas")
+        pwd = st.text_input("Password", type="password", key="app_password")
+        if st.button("Unlock"):
+            if pwd == APP_PASSWORD:
+                st.session_state["authenticated"] = True
+                st.experimental_rerun()
+            else:
+                st.error("Incorrect password.")
+        st.stop()
+
 st.markdown("""
 <div style='background-color:#e9f1f7; border:2px solid #c7d8e2; border-radius:12px; padding:1.5em; text-align:center; margin-bottom:2em;'>
     <h1 style='margin-bottom:0.2em; font-size:2.4em; color:#1a2b44;'>Weekly Rota Management</h1>
@@ -141,15 +159,18 @@ def display_latest_rota(rotas):
 # 🚀 App Entry
 # ─────────────────────────────────────────────
 render_sidebar()
-admin_login()
-
-if st.session_state.get("is_admin", False):
-    render_admin_panel(rotas, save_rotas, delete_rota)
 
 display_latest_rota(rotas)
 
 if "feedback" in st.session_state:
     st.success(st.session_state.pop("feedback"))
+
+require_app_password()
+
+admin_login()
+
+if st.session_state.get("is_admin", False):
+    render_admin_panel(rotas, save_rotas, delete_rota)
 
 # 🔁 Weekly Rota Planning
 selected_monday, days = select_week()


### PR DESCRIPTION
## Summary
- show saved rotas without requiring a password
- prompt for password only when managing rotas or using the admin panel
- clarify password usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599a0d954083259d63bdbe95a65d2b