### PR TITLE
Restrict planning tools by default

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,6 +28,8 @@ from weekly_rota_generation import (
 # ─────────────────────────────────────────────
 st.set_page_config(page_title="8216 ABP Yetminster Weekly Rota Planner", layout="wide")
 
+st.session_state.setdefault("is_admin", False)
+
 st.markdown("""
 <div style='background-color:#e9f1f7; border:2px solid #c7d8e2; border-radius:12px; padding:1.5em; text-align:center; margin-bottom:2em;'>
     <h1 style='margin-bottom:0.2em; font-size:2.4em; color:#1a2b44;'>Weekly Rota Management</h1>
@@ -79,14 +81,18 @@ def render_sidebar():
 # 🔐 Admin Login
 # ─────────────────────────────────────────────
 def admin_login():
-    with st.sidebar.expander("🔐 Admin Access", expanded=False):
-        admin_input = st.text_input("Enter admin password:", type="password", key="admin_password")
-        if admin_input == "17500#":
-            st.session_state["is_admin"] = True
-            st.success("Access granted. Admin panel is now visible.")
-        elif admin_input:
-            st.session_state["is_admin"] = False
-            st.error("Incorrect password.")
+    if st.session_state.get("is_admin"):
+        return
+
+    st.info("🔐 Enter the access code below to unlock rota planning tools.")
+    code_input = st.text_input("Access Code:", type="password", key="access_code")
+
+    if code_input == "17500#":
+        st.session_state["is_admin"] = True
+        st.success("Access granted. Planning tools unlocked.")
+    elif code_input:
+        st.session_state["is_admin"] = False
+        st.error("Incorrect code.")
 
 # ─────────────────────────────────────────────
 # 🔄 Display Latest Rota
@@ -143,10 +149,12 @@ def display_latest_rota(rotas):
 render_sidebar()
 admin_login()
 
-if st.session_state.get("is_admin", False):
-    render_admin_panel(rotas, save_rotas, delete_rota)
-
 display_latest_rota(rotas)
+
+if not st.session_state.get("is_admin", False):
+    st.stop()
+
+render_admin_panel(rotas, save_rotas, delete_rota)
 
 if "feedback" in st.session_state:
     st.success(st.session_state.pop("feedback"))


### PR DESCRIPTION
## Summary
- initialize `st.session_state['is_admin']` to `False`
- stop showing rota planning content unless the correct access code has been entered

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859a122663c8325b419e8c961b1bed2