### PR TITLE
Restrict planning tools by default

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,6 +28,8 @@ from weekly_rota_generation import (
 # ─────────────────────────────────────────────
 st.set_page_config(page_title="8216 ABP Yetminster Weekly Rota Planner", layout="wide")
 
+st.session_state.setdefault("is_admin", False)
+
 st.markdown("""
 <div style='background-color:#e9f1f7; border:2px solid #c7d8e2; border-radius:12px; padding:1.5em; text-align:center; margin-bottom:2em;'>
     <h1 style='margin-bottom:0.2em; font-size:2.4em; color:#1a2b44;'>Weekly Rota Management</h1>
@@ -79,14 +81,18 @@ def render_sidebar():
 # 🔐 Admin Login
 # ─────────────────────────────────────────────
 def admin_login():
-    with st.sidebar.expander("🔐 Admin Access", expanded=False):
-        admin_input = st.text_input("Enter admin password:", type="password", key="admin_password")
-        if admin_input == "17500#":
-            st.session_state["is_admin"] = True
-            st.success("Access granted. Admin panel is now visible.")
-        elif admin_input:
-            st.session_state["is_admin"] = False
-            st.error("Incorrect password.")
+    if st.session_state.get("is_admin"):
+        return
+
+    st.info("🔐 Enter the access code below to unlock rota planning tools.")
+    code_input = st.text_input("Access Code:", type="password", key="access_code")
+
+    if code_input == "17500#":
+        st.session_state["is_admin"] = True
+        st.success("Access granted. Planning tools unlocked.")
+    elif code_input:
+        st.session_state["is_admin"] = False
+        st.error("Incorrect code.")
 
 # ─────────────────────────────────────────────
 # 🔄 Display Latest Rota
@@ -143,13 +149,10 @@ def display_latest_rota(rotas):
 render_sidebar()
 admin_login()
 
-if st.session_state.get("is_admin", False):
-    render_admin_panel(rotas, save_rotas, delete_rota)
-
 display_latest_rota(rotas)
 
-if "feedback" in st.session_state:
-    st.success(st.session_state.pop("feedback"))
+if not st.session_state.get("is_admin", False):
+    st.stop()
 
 # 🔁 Weekly Rota Planning
 selected_monday, days = select_week()
@@ -173,3 +176,9 @@ if not rota_already_exists:
 
     if valid_days and not invalid_days:
         generate_and_display_rota(valid_days, daily_workers, daily_heads, rotas, inspectors, week_key, days)
+
+if st.session_state.get("is_admin", False):
+    render_admin_panel(rotas, save_rotas, delete_rota)
+
+    if "feedback" in st.session_state:
+        st.success(st.session_state.pop("feedback"))

--- a/weekly_rota_generation.py
+++ b/weekly_rota_generation.py
@@ -138,9 +138,11 @@ def check_existing_rota(week_key, rotas, selected_monday, is_admin, all_days, po
     rota_exists = False
     latest_week = max(rotas.keys()) if rotas else None
     latest_week_date = datetime.strptime(latest_week, "%Y-%m-%d").date() if latest_week else None
+    today = datetime.today().date()
 
     if week_key in rotas:
-        if selected_monday == latest_week_date:
+        latest_week_current = selected_monday == latest_week_date and (selected_monday + timedelta(days=4)) >= today
+        if latest_week_current:
             st.info("ℹ️ A rota already exists for the selected week and is displayed at the top.")
         else:
             st.warning(f"A rota already exists for the week starting {week_key}. Displaying saved rota:")


### PR DESCRIPTION
## Summary
- initialize `st.session_state['is_admin']` to `False`
- stop showing rota planning content unless the correct access code has been entered
- move admin panel to the bottom of the page
- show an info message and the latest rota before prompting for admin access
- only render the admin panel when logged in
- show saved rota when the latest week is no longer current

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859a122663c8325b419e8c961b1bed2