### PR TITLE
Fix renames to avoid merge conflicts

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,6 @@ from datetime import datetime, timedelta
 from core.algorithm import generate_rota
 from core.data_utils import load_rotas, save_rotas, delete_rota, get_saved_week_keys
 from app_texts import HOW_TO_USE, FAIR_ASSIGNMENT, WHATS_NEW, CHANGELOG_HISTORY
-from admin_panel import render_admin_panel
 from core.utils import generate_table_image
 from weekly_rota_generation import (
     select_week,
@@ -26,7 +25,7 @@ from weekly_rota_generation import (
 # ─────────────────────────────────────────────
 # 🌐 App Setup
 # ─────────────────────────────────────────────
-st.set_page_config(page_title="8216 ABP Yetminster Weekly Rota Planner", layout="wide")
+st.set_page_config(page_title="Homepage", layout="wide")
 
 st.session_state.setdefault("is_admin", False)
 
@@ -176,8 +175,3 @@ if not rota_already_exists:
     if valid_days and not invalid_days:
         generate_and_display_rota(valid_days, daily_workers, daily_heads, rotas, inspectors, week_key, days)
 
-if st.session_state.get("is_admin", False):
-    render_admin_panel(rotas, save_rotas, delete_rota)
-
-    if "feedback" in st.session_state:
-        st.success(st.session_state.pop("feedback"))

--- a/pages/admin.py
+++ b/pages/admin.py
@@ -1,0 +1,40 @@
+import streamlit as st
+from admin_panel import render_admin_panel
+from core.data_utils import load_rotas, save_rotas, delete_rota
+
+st.set_page_config(page_title="Admin Panel", layout="wide")
+
+st.session_state.setdefault("is_admin", False)
+
+
+def admin_login():
+    if st.session_state.get("is_admin"):
+        return
+    st.info("🔐 Enter the access code below to unlock admin tools.")
+    code_input = st.text_input("Access Code:", type="password")
+    if code_input == "17500#":
+        st.session_state["is_admin"] = True
+        st.success("Access granted. Admin tools unlocked.")
+    elif code_input:
+        st.session_state["is_admin"] = False
+        st.error("Incorrect code.")
+
+
+admin_login()
+
+if not st.session_state.get("is_admin", False):
+    st.stop()
+
+
+@st.cache_data
+def cached_load_rotas():
+    return load_rotas()
+
+
+rotas = cached_load_rotas()
+
+render_admin_panel(rotas, save_rotas, delete_rota)
+
+if "feedback" in st.session_state:
+    st.success(st.session_state.pop("feedback"))
+


### PR DESCRIPTION
## Summary
- revert file names back to `app.py` and `pages/admin.py`
- update devcontainer and README to use `app.py`
- keep page titles as "Homepage" and "Admin Panel"

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685abba35b4c8325b07d997c73c7f07d