### PR TITLE
Add user/password login for admin panel

### DIFF
--- a/pages/1_Admin Panel.py
+++ b/pages/1_Admin Panel.py
@@ -5,19 +5,24 @@ from core.data_utils import load_rotas, save_rotas, delete_rota
 st.set_page_config(page_title="Admin Panel", layout="wide")
 
 st.session_state.setdefault("is_admin", False)
+ADMIN_CREDENTIALS = {"admin": "17500#"}
 
 
 def admin_login():
     if st.session_state.get("is_admin"):
         return
-    st.info("🔐 Enter the access code below to unlock admin tools.")
-    code_input = st.text_input("Access Code:", type="password")
-    if code_input == "17500#":
+
+    st.info("🔐 Enter your admin credentials below to unlock admin tools.")
+    username = st.text_input("Username")
+    password = st.text_input("Password", type="password")
+
+    if username in ADMIN_CREDENTIALS and password == ADMIN_CREDENTIALS[username]:
         st.session_state["is_admin"] = True
+        st.session_state["admin_user"] = username
         st.success("Access granted. Admin tools unlocked.")
-    elif code_input:
+    elif username or password:
         st.session_state["is_admin"] = False
-        st.error("Incorrect code.")
+        st.error("Incorrect username or password.")
 
 
 admin_login()


### PR DESCRIPTION
## Summary
- require a username and password on the Admin Panel page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad13185e88325b0ab2f5a309f422a