### PR TITLE
Fix admin login separation

### DIFF
--- a/0_Homepage.py
+++ b/0_Homepage.py
@@ -27,7 +27,7 @@ from weekly_rota_generation import (
 # ─────────────────────────────────────────────
 st.set_page_config(page_title="8216 Weekly Rota")
 
-st.session_state.setdefault("is_admin", False)
+st.session_state.setdefault("is_planner", False)
 
 st.markdown("""
 <div style='background-color:#e9f1f7; border:2px solid #c7d8e2; border-radius:12px; padding:1.5em; text-align:center; margin-bottom:2em;'>
@@ -80,17 +80,17 @@ def render_sidebar():
 # 🔐 Admin Login
 # ─────────────────────────────────────────────
 def admin_login():
-    if st.session_state.get("is_admin"):
+    if st.session_state.get("is_planner"):
         return
 
     st.info("🔐 Enter the access code below to unlock rota planning tools.")
     code_input = st.text_input("Access Code:", type="password", key="access_code")
 
     if code_input == "17500#":
-        st.session_state["is_admin"] = True
+        st.session_state["is_planner"] = True
         st.success("Access granted. Planning tools unlocked.")
     elif code_input:
-        st.session_state["is_admin"] = False
+        st.session_state["is_planner"] = False
         st.error("Incorrect code.")
 
 # ─────────────────────────────────────────────
@@ -149,7 +149,7 @@ render_sidebar()
 display_latest_rota(rotas)
 admin_login()
 
-if not st.session_state.get("is_admin", False):
+if not st.session_state.get("is_planner", False):
     st.stop()
 
 # 🔁 Weekly Rota Planning
@@ -160,7 +160,7 @@ rota_already_exists = check_existing_rota(
     week_key=week_key,
     rotas=rotas,
     selected_monday=selected_monday,
-    is_admin=st.session_state.get("is_admin", False),
+    has_planner_access=st.session_state.get("is_planner", False),
     all_days=days,
     positions=POSITIONS
 )

--- a/pages/1_Admin Panel.py
+++ b/pages/1_Admin Panel.py
@@ -5,7 +5,10 @@ from core.data_utils import load_rotas, save_rotas, delete_rota
 st.set_page_config(page_title="Admin Panel", layout="wide")
 
 st.session_state.setdefault("is_admin", False)
-ADMIN_CREDENTIALS = {"admin": "17500#"}
+ADMIN_CREDENTIALS = {
+    "admin": "17500#",
+    "Marco": "429327",
+}
 
 
 def admin_login():

--- a/weekly_rota_generation.py
+++ b/weekly_rota_generation.py
@@ -134,7 +134,7 @@ def generate_and_display_rota(valid_days, daily_workers, daily_heads, rotas, ins
         st.cache_data.clear()
         st.rerun()
 
-def check_existing_rota(week_key, rotas, selected_monday, is_admin, all_days, positions):
+def check_existing_rota(week_key, rotas, selected_monday, has_planner_access, all_days, positions):
     rota_exists = False
     latest_week = max(rotas.keys()) if rotas else None
     latest_week_date = datetime.strptime(latest_week, "%Y-%m-%d").date() if latest_week else None
@@ -157,7 +157,7 @@ def check_existing_rota(week_key, rotas, selected_monday, is_admin, all_days, po
             existing_df = existing_df[positions]
             st.dataframe(existing_df)
 
-        if not is_admin:
+        if not has_planner_access:
             st.stop()
         else:
             rota_exists = True


### PR DESCRIPTION
## Summary
- separate homepage planning access from admin panel login
- add admin credentials for Marco

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad44f51a883259d893dc8eda0813a