### PR TITLE
Add deleted rota archive

### DIFF
--- a/admin_panel.py
+++ b/admin_panel.py
@@ -75,7 +75,7 @@ def fetch_logs_from_google_sheet():
         return []
 
 # ─── Admin Panel ───
-def render_admin_panel(rotas, save_rotas, delete_rota):
+def render_admin_panel(rotas, save_rotas, delete_rota, archive_deleted_rota):
     if not st.session_state.get("is_admin", False):
         return
 
@@ -164,8 +164,13 @@ def render_admin_panel(rotas, save_rotas, delete_rota):
                         "new_value": "-",
                         "admin_users": st.session_state.get("admin_user", "admin")
                     })
+                    deleted_rota = delete_rota(wk)
+                    archive_deleted_rota(
+                        wk,
+                        deleted_rota,
+                        st.session_state.get("admin_user", "admin"),
+                    )
                     rotas.pop(wk)
-                    delete_rota(wk)
                     st.session_state["feedback"] = f"🗑️ Rota for {wk} deleted."
                     st.cache_data.clear()
                     st.rerun()

--- a/core/data_utils.py
+++ b/core/data_utils.py
@@ -11,6 +11,7 @@ from datetime import datetime
 
 # Google Sheets bağlantısı
 SHEET_NAME = "rota_data"
+DELETED_SHEET_NAME = "deleted_rota"
 
 POSITIONS = ["CAR1", "HEAD", "CAR2", "OFFAL", "FCI", "OFFLINE"]
 
@@ -21,6 +22,14 @@ def get_sheet():
     )
     gc = gspread.authorize(credentials)
     return gc.open(SHEET_NAME).sheet1
+
+def get_deleted_sheet():
+    scope = ["https://spreadsheets.google.com/feeds", "https://www.googleapis.com/auth/drive"]
+    credentials = Credentials.from_service_account_info(
+        st.secrets["gcp_service_account"], scopes=scope
+    )
+    gc = gspread.authorize(credentials)
+    return gc.open(DELETED_SHEET_NAME).sheet1
 
 def save_rotas(week_key: str, rota_dict: Dict[str, Dict[str, str]]):
     sheet = get_sheet()
@@ -70,10 +79,28 @@ def load_rotas():
 def delete_rota(week_key: str):
     sheet = get_sheet()
     rows = sheet.get_all_values()
-    header = rows[0] if rows else []
+    deleted_data = {}
+    for row in rows:
+        if len(row) >= 2 and row[0] == week_key and row[0] != "week_start":
+            day = row[1]
+            roles = dict(zip(POSITIONS, row[2:2 + len(POSITIONS)]))
+            deleted_data[day] = roles
+
     rows_to_keep = [row for row in rows if row[0] != week_key or row[0] == "week_start"]
     sheet.clear()
     for row in rows_to_keep:
+        sheet.append_row(row)
+
+    return deleted_data
+
+def archive_deleted_rota(week_key: str, rota_dict: Dict[str, Dict[str, str]], admin_user: str):
+    sheet = get_deleted_sheet()
+    existing = sheet.get_all_values()
+    header = ["week_start", "day", "deleted_by"] + POSITIONS
+    if not existing:
+        sheet.append_row(header)
+    for day, roles in rota_dict.items():
+        row = [week_key, day, admin_user] + [roles.get(pos, "") for pos in POSITIONS]
         sheet.append_row(row)
 
 def get_saved_week_keys():

--- a/pages/1_Admin Panel.py
+++ b/pages/1_Admin Panel.py
@@ -1,6 +1,6 @@
 import streamlit as st
 from admin_panel import render_admin_panel
-from core.data_utils import load_rotas, save_rotas, delete_rota
+from core.data_utils import load_rotas, save_rotas, delete_rota, archive_deleted_rota
 
 st.set_page_config(page_title="Admin Panel", layout="wide")
 
@@ -41,7 +41,7 @@ def cached_load_rotas():
 
 rotas = cached_load_rotas()
 
-render_admin_panel(rotas, save_rotas, delete_rota)
+render_admin_panel(rotas, save_rotas, delete_rota, archive_deleted_rota)
 
 if "feedback" in st.session_state:
     st.success(st.session_state.pop("feedback"))


### PR DESCRIPTION
## Summary
- archive deleted rota rows in a dedicated `deleted_rota` sheet
- update admin panel to store deleted rota information and record who deleted it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad916dbf88325923c980ccb8bf0e7