### PR TITLE
Implement login button on admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A smart, fair, and fully automated rota management system designed for ABP Yetmi
 - 📈 **Monthly FCI/OFFLINE Overview**
 - 🗂️ **Editable & Collapsible Saved Weekly Rotas**
 - 🎨 **Modern UI with Auto Validation & Warnings**
+- 🗑️ **Deleted Rotas Archived to Google Sheets**
 
 ## 🚀 Version 1.3.5 (Stable)
 

--- a/app_texts.py
+++ b/app_texts.py
@@ -10,7 +10,15 @@ HOW_TO_USE = """
 1. Select the **Monday** of the week you want to plan.  
 2. For each weekday, choose exactly **6 unique inspectors**, one of whom is the **HEAD**.  
 3. Press **Generate Rota** to assign roles fairly and save the rota automatically.  
-4. You can view the current week's rota summary directly on the homepage.  
+4. You can view the current week's rota summary directly on the homepage.
+"""
+
+# Guidance for the admin panel sidebar
+ADMIN_PANEL_HELP = """
+1. **Log in** with your admin username and password.
+2. The **Saved Weekly Rotas** section lets you view, edit or delete any week.
+3. Use **Clear Cached Data** if updates don't show immediately.
+4. All changes are logged for accountability.
 """
 
 FAIR_ASSIGNMENT = """

--- a/core/data_utils.py
+++ b/core/data_utils.py
@@ -96,11 +96,11 @@ def delete_rota(week_key: str):
 def archive_deleted_rota(week_key: str, rota_dict: Dict[str, Dict[str, str]], admin_user: str):
     sheet = get_deleted_sheet()
     existing = sheet.get_all_values()
-    header = ["week_start", "day", "deleted_by"] + POSITIONS
+    header = ["week_start", "day"] + POSITIONS + ["admin_users"]
     if not existing:
         sheet.append_row(header)
     for day, roles in rota_dict.items():
-        row = [week_key, day, admin_user] + [roles.get(pos, "") for pos in POSITIONS]
+        row = [week_key, day] + [roles.get(pos, "") for pos in POSITIONS] + [admin_user]
         sheet.append_row(row)
 
 def get_saved_week_keys():

--- a/pages/1_Admin Panel.py
+++ b/pages/1_Admin Panel.py
@@ -1,8 +1,17 @@
 import streamlit as st
 from admin_panel import render_admin_panel
 from core.data_utils import load_rotas, save_rotas, delete_rota, archive_deleted_rota
+from app_texts import ADMIN_PANEL_HELP
 
 st.set_page_config(page_title="Admin Panel", layout="wide")
+
+
+def render_sidebar():
+    with st.sidebar.expander("📘 Admin Panel Guide", expanded=True):
+        st.markdown(ADMIN_PANEL_HELP)
+
+
+render_sidebar()
 
 st.session_state.setdefault("is_admin", False)
 ADMIN_CREDENTIALS = {
@@ -16,16 +25,17 @@ def admin_login():
         return
 
     st.info("🔐 Enter your username and password below to unlock admin tools.")
-    username = st.text_input("Username")
-    password = st.text_input("Password", type="password")
+    username = st.text_input("Username", key="admin_username")
+    password = st.text_input("Password", type="password", key="admin_password")
 
-    if username in ADMIN_CREDENTIALS and password == ADMIN_CREDENTIALS[username]:
-        st.session_state["is_admin"] = True
-        st.session_state["admin_user"] = username
-        st.success("Access granted. Admin tools unlocked.")
-    elif username or password:
-        st.session_state["is_admin"] = False
-        st.error("Incorrect username or password.")
+    if st.button("Login"):
+        if username in ADMIN_CREDENTIALS and password == ADMIN_CREDENTIALS[username]:
+            st.session_state["is_admin"] = True
+            st.session_state["admin_user"] = username
+            st.success("Access granted. Admin tools unlocked.")
+        else:
+            st.session_state["is_admin"] = False
+            st.error("Incorrect username or password.")
 
 
 admin_login()

--- a/tests/test_archive_deleted.py
+++ b/tests/test_archive_deleted.py
@@ -1,0 +1,57 @@
+import types
+
+import sys
+
+# Provide a dummy streamlit module
+sys.modules['streamlit'] = types.SimpleNamespace(secrets={}, cache_data=types.SimpleNamespace(clear=lambda: None))
+sys.modules['gspread'] = types.SimpleNamespace()
+sys.modules['google.oauth2.service_account'] = types.SimpleNamespace(Credentials=types.SimpleNamespace(from_service_account_info=lambda info, scopes=None: None))
+
+import os
+
+# Ensure the repository root is on the Python path
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+
+import core.data_utils as data_utils
+
+class FakeSheet:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+    def get_all_values(self):
+        return [list(r) for r in self.rows]
+    def append_row(self, row):
+        self.rows.append(list(row))
+    def clear(self):
+        self.rows = []
+
+
+def test_delete_and_archive_rota():
+    week_key = "2025-01-06"
+    header = ["week_start", "day"] + data_utils.POSITIONS
+    rows = [
+        header,
+        [week_key, "Monday", "A", "H", "B", "C", "D", "E"],
+        [week_key, "Tuesday", "A2", "H2", "B2", "C2", "D2", "E2"],
+        ["2025-01-13", "Monday", "X", "H", "Y", "Z", "W", "Q"],
+    ]
+    sheet = FakeSheet(rows)
+    deleted_sheet = FakeSheet([])
+
+    original_get_sheet = data_utils.get_sheet
+    original_get_deleted = data_utils.get_deleted_sheet
+    data_utils.get_sheet = lambda: sheet
+    data_utils.get_deleted_sheet = lambda: deleted_sheet
+
+    try:
+        deleted = data_utils.delete_rota(week_key)
+        data_utils.archive_deleted_rota(week_key, deleted, "admin")
+    finally:
+        data_utils.get_sheet = original_get_sheet
+        data_utils.get_deleted_sheet = original_get_deleted
+
+    assert week_key not in [r[0] for r in sheet.rows if r]
+    assert deleted_sheet.rows[0] == ["week_start", "day"] + data_utils.POSITIONS + ["admin_users"]
+    assert deleted_sheet.rows[1][-1] == "admin"
+    assert len(deleted_sheet.rows) == 1 + len(deleted)
+


### PR DESCRIPTION
## Summary
- require explicit login button on admin page
- add sidebar help text for admin panel
- ensure deleted weeks are archived in Google Sheets with admin user in last column
- add tests for deleting and archiving rota data
- drop unused import from archive test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685aef6dff608325b489133728026f41