### PR TITLE
Show deleted rotas & update archive

### DIFF
--- a/pages/1_Admin Panel.py
+++ b/pages/1_Admin Panel.py
@@ -49,9 +49,16 @@ def cached_load_rotas():
     return load_rotas()
 
 
-rotas = cached_load_rotas()
+@st.cache_data
+def cached_load_deleted_rotas():
+    from core.data_utils import load_deleted_rotas
+    return load_deleted_rotas()
 
-render_admin_panel(rotas, save_rotas, delete_rota, archive_deleted_rota)
+
+rotas = cached_load_rotas()
+deleted_rotas = cached_load_deleted_rotas()
+
+render_admin_panel(rotas, deleted_rotas, save_rotas, delete_rota, archive_deleted_rota)
 
 if "feedback" in st.session_state:
     st.success(st.session_state.pop("feedback"))

--- a/tests/test_archive_deleted.py
+++ b/tests/test_archive_deleted.py
@@ -47,14 +47,13 @@ def test_delete_and_archive_rota():
 
     try:
         deleted = data_utils.delete_rota(week_key)
-        data_utils.archive_deleted_rota(week_key, deleted, "admin")
+        data_utils.archive_deleted_rota(week_key, deleted)
     finally:
         data_utils.get_sheet = original_get_sheet
         data_utils.get_deleted_sheet = original_get_deleted
 
     assert week_key not in [r[0] for r in sheet.rows if r]
-    assert deleted_sheet.rows[0] == ["week_start", "day"] + data_utils.POSITIONS + ["admin_users"]
-    assert deleted_sheet.rows[1][-1] == "admin"
-    assert deleted_sheet.rows[0][:3] == ["week_start", "day", "deleted_by"]
+    assert deleted_sheet.rows[0] == ["week_start", "day"] + data_utils.POSITIONS
+    assert len(deleted_sheet.rows[1]) == len(deleted_sheet.rows[0])
     assert len(deleted_sheet.rows) == 1 + len(deleted)
 


### PR DESCRIPTION
## Summary
- stop recording admin usernames in `deleted_rota` sheet
- expose deleted rota information through `load_deleted_rotas`
- show deleted rotas section in the admin panel
- update admin panel page to supply deleted rotas
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b06a5c2b88325b6826c7e023b1f52